### PR TITLE
dev/command-serialization init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 
 # Run the tests for the set command
 test set:
-	go test -v ./internal/app/set
+	go test -v ./internal/pkg/serialization
 
 # View the makefile commads
 view:

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ clean:
 	go clean
 	rm ./bin/memcached-client
 
-# Run the tests for the set command
-test set:
+# Run the tests for command serialization
+test cmd serialization:
 	go test -v ./internal/pkg/serialization
 
 # View the makefile commads

--- a/internal/app/set/main.go
+++ b/internal/app/set/main.go
@@ -6,8 +6,8 @@ import (
 )
 
 // Creates the byte stream for the command section of the tcp protocol
-func SerializeSetCommand(key string, flags uint16, exptime int, size int) *bytes.Buffer {
-	msg := fmt.Sprintf("set %s %d %d %d\r\n", key, flags, exptime, size)
+func SerializeSetCommand(cmd string, key string, flags uint16, exptime int, size int) *bytes.Buffer {
+	msg := fmt.Sprintf("%s %s %d %d %d\r\n", cmd, key, flags, exptime, size)
 	byteStream := bytes.NewBufferString(msg)
 
 	return byteStream

--- a/internal/pkg/serialization/main.go
+++ b/internal/pkg/serialization/main.go
@@ -2,15 +2,24 @@ package serialization
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 )
 
 // Creates the byte stream for the command section of the tcp protocol
+// Valid commands: set, add, replace, append, prepend
 func SerializeCommand(cmd string, key string, flags uint16, exptime int, size int) (*bytes.Buffer, error) {
-	msg := fmt.Sprintf("%s %s %d %d %d\r\n", cmd, key, flags, exptime, size)
-	byteStream := bytes.NewBufferString(msg)
 
-	return byteStream, nil
+	switch cmd {
+	case "set", "add", "replace", "append", "prepend":
+		msg := fmt.Sprintf("%s %s %d %d %d\r\n", cmd, key, flags, exptime, size)
+		byteStream := bytes.NewBufferString(msg)
+
+		return byteStream, nil
+	}
+
+	e := fmt.Sprintf("%s is not a valid command. Enter one of set, add, replace, append, prepend", cmd)
+	return nil, errors.New(e)
 }
 
 // Creates the byte stream for the datablock section of the tcp protocol

--- a/internal/pkg/serialization/main.go
+++ b/internal/pkg/serialization/main.go
@@ -1,4 +1,4 @@
-package set
+package serialization
 
 import (
 	"bytes"
@@ -6,15 +6,15 @@ import (
 )
 
 // Creates the byte stream for the command section of the tcp protocol
-func SerializeSetCommand(cmd string, key string, flags uint16, exptime int, size int) *bytes.Buffer {
+func SerializeCommand(cmd string, key string, flags uint16, exptime int, size int) (*bytes.Buffer, error) {
 	msg := fmt.Sprintf("%s %s %d %d %d\r\n", cmd, key, flags, exptime, size)
 	byteStream := bytes.NewBufferString(msg)
 
-	return byteStream
+	return byteStream, nil
 }
 
 // Creates the byte stream for the datablock section of the tcp protocol
-func SerializeSetDataBlock(dataBlock string) *bytes.Buffer {
+func SerializeDataBlock(dataBlock string) *bytes.Buffer {
 	msg := fmt.Sprintf("%s\r\n", dataBlock)
 	byteStream := bytes.NewBufferString(msg)
 
@@ -22,7 +22,7 @@ func SerializeSetDataBlock(dataBlock string) *bytes.Buffer {
 }
 
 // Creates a string of the byte stream response from the server
-func DeserializeSetCommand(b *bytes.Buffer) string {
+func DeserializeCommand(b *bytes.Buffer) string {
 	msg := b.String()
 
 	return msg

--- a/internal/pkg/serialization/main_test.go
+++ b/internal/pkg/serialization/main_test.go
@@ -34,8 +34,8 @@ func TestSerializeCommand(t *testing.T) {
 		t.Fatal(e)
 	}
 
-	if t2.String() != "set secret 0 900 44\r\n" {
-		e := fmt.Sprintf("Incorrect buffer string, got=%s, expected=%s", t2.String(), "set secret 0 900 44\r\n")
+	if t2.String() != "add secret 0 900 44\r\n" {
+		e := fmt.Sprintf("Incorrect buffer string, got=%s, expected=%s", t2.String(), "add secret 0 900 44\r\n")
 		t.Fatal(e)
 	}
 
@@ -71,8 +71,8 @@ func TestSerializeCommand(t *testing.T) {
 		t.Fatal(e)
 	}
 
-	// NOTE: Test case 4 => "prepend data 0 0 7\r\n"
-	t5, err := SerializeCommand("append", "data", 0, 0, 7)
+	// NOTE: Test case 5 => "prepend data 0 0 7\r\n"
+	t5, err := SerializeCommand("prepend", "data", 0, 0, 7)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/serialization/main_test.go
+++ b/internal/pkg/serialization/main_test.go
@@ -1,4 +1,4 @@
-package set
+package serialization
 
 import (
 	"bytes"
@@ -6,11 +6,12 @@ import (
 	"testing"
 )
 
-func TestSerializeSetCommand(t *testing.T) {
+func TestSerializeCommand(t *testing.T) {
 	// NOTE: Test case 1 => "set greeting 0 0 13\r\n"
-	// 13 bytes for the string "Hello, World!"
-	// no expiration time
-	t1 := SerializeSetCommand("greeting", 0, 0, 13)
+	t1, err := SerializeCommand("set", "greeting", 0, 0, 13)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if t1.Len() != 21 {
 		e := fmt.Sprintf("Buffer size incorrect, got=%d bytes, expected=%d bytes", t1.Len(), 21)
@@ -22,10 +23,11 @@ func TestSerializeSetCommand(t *testing.T) {
 		t.Fatal(e)
 	}
 
-	// NOTE: Test case 2 => "set secret 0 900 44\r\n"
-	// 44 bytes for the string "secret message for memcached server to store"
-	// 900 second expiration time
-	t2 := SerializeSetCommand("secret", 0, 900, 44)
+	// NOTE: Test case 2 => "add secret 0 900 44\r\n"
+	t2, err := SerializeCommand("add", "secret", 0, 900, 44)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if t2.Len() != 21 {
 		e := fmt.Sprintf("Buffer size incorrect, got=%d bytes, expected=%d bytes", t2.Len(), 21)
@@ -36,11 +38,59 @@ func TestSerializeSetCommand(t *testing.T) {
 		e := fmt.Sprintf("Incorrect buffer string, got=%s, expected=%s", t2.String(), "set secret 0 900 44\r\n")
 		t.Fatal(e)
 	}
+
+	// NOTE: Test case 3 => "replace greeting 0 0 10\r\n"
+	t3, err := SerializeCommand("replace", "greeting", 0, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if t3.Len() != 25 {
+		e := fmt.Sprintf("Buffer size incorrect, got=%d bytes, expected=%d bytes", t3.Len(), 25)
+		t.Fatal(e)
+	}
+
+	if t3.String() != "replace greeting 0 0 10\r\n" {
+		e := fmt.Sprintf("Incorrect buffer string, got=%s, expected=%s", t3.String(), "replace greeting 0 0 10\r\n")
+		t.Fatal(e)
+	}
+
+	// NOTE: Test case 4 => "append secret 0 0 10\r\n"
+	t4, err := SerializeCommand("append", "secret", 0, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if t4.Len() != 22 {
+		e := fmt.Sprintf("Buffer size is incorrect, got=%d bytes, expected=%d bytes", t4.Len(), 22)
+		t.Fatal(e)
+	}
+
+	if t4.String() != "append secret 0 0 10\r\n" {
+		e := fmt.Sprintf("Incorrect buffer string, got=%s, expected=%s", t4.String(), "append secret 0 0 10\r\n")
+		t.Fatal(e)
+	}
+
+	// NOTE: Test case 4 => "prepend data 0 0 7\r\n"
+	t5, err := SerializeCommand("append", "data", 0, 0, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if t5.Len() != 20 {
+		e := fmt.Sprintf("Buffer size is incorrect, got=%d bytes, expected=%d bytes", t5.Len(), 20)
+		t.Fatal(e)
+	}
+
+	if t5.String() != "prepend data 0 0 7\r\n" {
+		e := fmt.Sprintf("Incorrect buffer string, got=%s, expected=%s", t5.String(), "prepend data 0 0 7\r\n")
+		t.Fatal(e)
+	}
 }
 
-func TestSerializeSetDataBlock(t *testing.T) {
+func TestSerializeDataBlock(t *testing.T) {
 	// NOTE: Test case 1 => "Hello, World!\r\n"
-	t1 := SerializeSetDataBlock("Hello, World!")
+	t1 := SerializeDataBlock("Hello, World!")
 
 	if t1.Len() != 15 {
 		e := fmt.Sprintf("Buffer size incorrect, got=%d, expected=%d", t1.Len(), 15)
@@ -53,9 +103,8 @@ func TestSerializeSetDataBlock(t *testing.T) {
 	}
 
 	// NOTE: Test case 2 => "secret message for memcached server to store\r\n"
-	t2 := SerializeSetDataBlock("secret message for memcached server to store")
+	t2 := SerializeDataBlock("secret message for memcached server to store")
 
-	// expected size is 48 bytes => secret message for memcached server to store\r\n
 	if t2.Len() != 46 {
 		e := fmt.Sprintf("Buffer size incorrect, got=%d bytes, expected=%d bytes", t2.Len(), 48)
 		t.Fatal(e)
@@ -67,14 +116,14 @@ func TestSerializeSetDataBlock(t *testing.T) {
 	}
 }
 
-func TestDeserializeSetCommand(t *testing.T) {
+func TestDeserializeCommand(t *testing.T) {
 	// The tcp server will responsed to a command with one of the following:
 	// STORED\r\n
 	// NOT_STORED\r\n
 
 	// NOTE: Test case 1 => STORED\r\n
 	t1buffer := bytes.NewBufferString("STORED\r\n")
-	t1 := DeserializeSetCommand(t1buffer)
+	t1 := DeserializeCommand(t1buffer)
 
 	if t1 != "STORED\r\n" {
 		e := fmt.Sprintf("Deserialized buffer is incorrect, got=%s, expected=%s", t1, "STORED\r\n")
@@ -83,7 +132,7 @@ func TestDeserializeSetCommand(t *testing.T) {
 
 	// NOTE: Test case 2 => NOT_STORED\r\n
 	t2buffer := bytes.NewBufferString("NOT_STORED\r\n")
-	t2 := DeserializeSetCommand(t2buffer)
+	t2 := DeserializeCommand(t2buffer)
 
 	if t2 != "NOT_STORED\r\n" {
 		e := fmt.Sprintf("Deserialized buffer is incorrect, got=%s, expected=%s", t2, "NOT_STORED\r\n")


### PR DESCRIPTION
## Description
This PR will address the serialization process for the client's support Memcached commands. All of the commands will be serialized and deserialized by the same functions, currently defined in `internal/app/set`
The current folder structure for this will change, and more tests will be added for the other commands

The new folder structure, holding the serialize and deserialize functionality and tests will look like this:

`internal/pkg/serialization`