### PR TITLE
dev/cli-command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ build:
 
 # Run the root command 
 run: build
-	@./bin/memcached-client
+	@./bin/ccmc
 
 # Clean project files and remove current binary in ./bin
 clean:
 	go clean
-	rm ./bin/memcached-client
+	rm ./bin/ccmc
 
 # Run the tests for command serialization
 test cmd serialization:

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// getCmd represents the get command
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("get called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(getCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (
@@ -10,9 +6,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// getCmd represents the get command
 var getCmd = &cobra.Command{
 	Use:   "get",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
 	Short: "A brief description of your command",
 	Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
@@ -21,20 +17,14 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("get called")
+		fmt.Printf("get called, host=%s, port=%d\n", host, port)
+
+		for _, arg := range args {
+			fmt.Printf("%s\n", arg)
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(getCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,15 +1,21 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 )
 
+var (
+	host string
+	port int
+)
+
 var rootCmd = &cobra.Command{
 	Use:   "ccmc",
 	Short: "Client for interacting with a memcached server",
-	Long: `Welcome to eh memcahced CLI!
+	Long: `Welcome to the memcahced CLI!
 
 	Memcached is a free, open-source, high-performance, distributed memory object caching system. It is intended to speed up dynamic web applications by reducing database load. It is also an in-memory key-value store for small chunks of arbitrary data retrieved from back-end systems with higher latency. It is simple yet powerful. Its simple design promotes quick deployment, and ease of development, and solves many problems facing large data caches. Its relatively simple API is available for most popular languages. It uses a simple text-based network protocol, making it a great platform to learn how to build network clients and servers.
 
@@ -21,7 +27,9 @@ var rootCmd = &cobra.Command{
 	append - Add the data to an existing key, after the existing data
 	prepend - Add the data to an exisiting key, before the existing data
 	`,
-	// Run: func(cmd *cobra.Command, args []string) { },
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("hostname=%s port=%d", host, port)
+	},
 }
 
 func Execute() {
@@ -33,4 +41,7 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	rootCmd.Flags().StringVarP(&host, "host", "o", "localhost", "Host address of tcp client")
+	rootCmd.Flags().IntVarP(&port, "port", "p", 11211, "Port of the client address")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,9 +9,18 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "ccmc",
 	Short: "Client for interacting with a memcached server",
-	Long:  `Memcached is a simple yet powerful server with client libraries in many programming languages. But sometimes it’s useful to be able to interact with a server from the command line. For example it’s useful to be able to use curl to fetch web pages or test/automate calls to RESTful API.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
+	Long: `Welcome to eh memcahced CLI!
+
+	Memcached is a free, open-source, high-performance, distributed memory object caching system. It is intended to speed up dynamic web applications by reducing database load. It is also an in-memory key-value store for small chunks of arbitrary data retrieved from back-end systems with higher latency. It is simple yet powerful. Its simple design promotes quick deployment, and ease of development, and solves many problems facing large data caches. Its relatively simple API is available for most popular languages. It uses a simple text-based network protocol, making it a great platform to learn how to build network clients and servers.
+
+	The CLI client communicates with memcached over a TCP connection. The support commands in this client are:
+
+	set - store some data
+	add - store some data, only if the server doesn't already hold data for this key
+	replace - store some data, only if the server already holds data for this key
+	append - Add the data to an existing key, after the existing data
+	prepend - Add the data to an exisiting key, before the existing data
+	`,
 	// Run: func(cmd *cobra.Command, args []string) { },
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,6 @@ func Execute() {
 func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	rootCmd.Flags().StringVarP(&host, "host", "o", "localhost", "Host address of tcp client")
-	rootCmd.Flags().IntVarP(&port, "port", "p", 11211, "Port of the client address")
+	rootCmd.PersistentFlags().StringVarP(&host, "host", "o", "localhost", "Host address of tcp client")
+	rootCmd.PersistentFlags().IntVarP(&port, "port", "p", 11211, "Port of the client address")
 }

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Args:  cobra.MatchAll(cobra.ExactArgs(2)),
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("set called host=%s, port=%d\n", host, port)
+
+		for _, arg := range args {
+			fmt.Printf("%s\n", arg)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(setCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/luka2220/tools/memcached-client
+module github.com/luka2220/tools/ccmc
 
 go 1.21.5
 
+require github.com/spf13/cobra v1.8.1
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/luka2220/tools/memcached-client/cmd"
+	"github.com/luka2220/tools/ccmc/cmd"
 )
 
 func main() {


### PR DESCRIPTION
## Description
This PR adds the cli command, arguments, and flag options for:

* starting the client
* defining port numbers and IP addresses
* running a Memcached command
* accepting the Memcached command options (key, flags, expiry time, bytes)